### PR TITLE
Added moduleOverrideWebpackPlugin and componentOverrideMapping files

### DIFF
--- a/packages/cpse-template/src/componentOverrideMapping.js
+++ b/packages/cpse-template/src/componentOverrideMapping.js
@@ -1,0 +1,6 @@
+/**
+ * Mappings for overwrites
+ * example: [`@magento/venia-ui/lib/components/Main/main.js`]: './lib/components/Main/main.js'
+ */
+module.exports = componentOverride = {
+};

--- a/packages/cpse-template/src/intercept.js
+++ b/packages/cpse-template/src/intercept.js
@@ -4,6 +4,9 @@
  *
  * If do want extend @magento/peregrine or @magento/venia-ui
  * you should add them to peerDependencies to your package.json
+ *
+ * If you want to add overwrites for @magento/venia-ui components you can use
+ * moduleOverrideWebpackPlugin and componentOverrideMapping
  */
 module.exports = targets => {
   targets.of('@magento/pwa-buildpack').specialFeatures.tap(flags => {

--- a/packages/cpse-template/src/moduleOverrideWebpackPlugin.js
+++ b/packages/cpse-template/src/moduleOverrideWebpackPlugin.js
@@ -1,0 +1,74 @@
+const path = require('path');
+const glob = require('glob');
+
+module.exports = class NormalModuleOverridePlugin {
+    constructor(moduleOverrideMap) {
+        this.name = 'NormalModuleOverridePlugin';
+        this.moduleOverrideMap = moduleOverrideMap;
+    }
+
+    requireResolveIfCan(id, options = undefined) {
+        try {
+            return require.resolve(id, options);
+        } catch (e) {
+            return undefined;
+        }
+    }
+
+    resolveModulePath(context, request) {
+        const filePathWithoutExtension = path.resolve(context, request);
+        const files = glob.sync(`${filePathWithoutExtension}@(|.*)`);
+
+        if (files.length === 0) {
+            throw new Error(`There is no file '${filePathWithoutExtension}'`);
+        }
+
+        if (files.length > 1) {
+            throw new Error(
+                `There is more than one file '${filePathWithoutExtension}'`
+            );
+        }
+
+        return require.resolve(files[0]);
+    }
+
+    resolveModuleOverrideMap(context, map) {
+        return Object.keys(map).reduce(
+            (result, x) => ({
+                ...result,
+                [require.resolve(x)]:
+                this.requireResolveIfCan(map[x]) ||
+                this.resolveModulePath(context, map[x]),
+            }),
+            {}
+        );
+    }
+    apply(compiler) {
+        if (Object.keys(this.moduleOverrideMap).length === 0) {
+            return;
+        }
+
+        const moduleMap = this.resolveModuleOverrideMap(
+            compiler.context,
+            this.moduleOverrideMap
+        );
+
+        compiler.hooks.normalModuleFactory.tap(this.name, (nmf) => {
+            nmf.hooks.beforeResolve.tap(this.name, (resolve) => {
+                if (!resolve) {
+                    return;
+                }
+
+                const moduleToReplace = this.requireResolveIfCan(resolve.request, {
+                    paths: [resolve.context],
+                });
+
+                if (moduleToReplace && moduleMap[moduleToReplace]) {
+                    resolve.request = moduleMap[moduleToReplace];
+                }
+                
+                return resolve;
+            });
+        });
+    }
+};


### PR DESCRIPTION
Usually if a developer work on the PWA Studio extension, he has to add overwrites for @magento/venia-ui components. 
I've added the possibility to use a predefined override Webpack plugin and file where a developer can add their mappings.

Let me know what do you think.